### PR TITLE
Add repo to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
     "build": "ember build",
     "test": "ember test"
   },
-  "repository": "",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/runspired/smoke-and-mirrors"
+  },
   "engines": {
     "node": ">= 0.10.0"
   },


### PR DESCRIPTION
This is so that npmjs.org add a link to the repo from https://www.npmjs.com/package/smoke-and-mirrors
