### PR TITLE
Fixed link to occlusion-collection.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,4 +58,4 @@ tables, selects, lists, each, and bi-directional infinite scrolling.
 
 ## Documentation
 
-- [Occlusion Collection](./docs/api/occlusion-collection.md)
+- [Occlusion Collection](./docs/occlusion-collection.md)


### PR DESCRIPTION
Or may better move it to proper path 'docs/api'?
