### PR TITLE
fix blueprint step to properly install bower dependencies

### DIFF
--- a/blueprints/smoke-and-mirrors/index.js
+++ b/blueprints/smoke-and-mirrors/index.js
@@ -3,7 +3,7 @@ module.exports = {
   normalizeEntityName: function() {},
 
   afterInstall: function() {
-    this.addBowerPackagesToProject([
+    return this.addBowerPackagesToProject([
       { name: 'animation-frame', target: '~0.2.4' }
     ]);
   }


### PR DESCRIPTION
closes runspired/smoke-and-mirrors#34
