### PR TITLE
Fix incorrect key in vertical-collection template

### DIFF
--- a/app/templates/components/vertical-collection.hbs
+++ b/app/templates/components/vertical-collection.hbs
@@ -1,4 +1,4 @@
-{{#each __content key="@identity" as |item|}}
+{{#each content key="@identity" as |item|}}
   {{#vertical-item
     defaultHeight=defaultHeight
     tagName=itemTagName


### PR DESCRIPTION
Finally upgrading to 1.13 =) Noticed s&m 0.2.2 vertical collection was throwing an error in `_cycleViews` because there were no child components registered - this seems to fix the issue.
