### PR TITLE
only keep last two images in async-image

### DIFF
--- a/addon/components/async-image.js
+++ b/addon/components/async-image.js
@@ -59,6 +59,7 @@ export default Ember.Component.extend({
       this.set('_image', $image);
       $image.on('load', function () {
         self.set('isLoaded', true);
+        jQuery('img:not(:last-child)', $view).remove();
         $view.append($image);
       });
     }


### PR DESCRIPTION
if one `async-image` instance is used and `src` changed n times it causes n `img` tags to be in the dom which degrades performance. this fix removes all but the last two `img` tags so that there is no bloat and css transitions are still possible.
