### PR TITLE
[FEAT] Router Service

### DIFF
--- a/addon/extensions/route.js
+++ b/addon/extensions/route.js
@@ -1,0 +1,23 @@
+import Ember from 'ember';
+
+const {
+  inject,
+  Route,
+  on,
+  } = Ember;
+
+function logMethod(name) {
+  return function() {
+    let org = this._super(...arguments);
+    console.log('Hook: ' + name, arguments);
+    debugger;
+    return org;
+  }
+}
+
+export default Route.extend({
+  enter: logMethod('enter'),
+  exit: logMethod('exit'),
+  didTransition: logMethod('didTransition'),
+  activate: logMethod('activate')
+});

--- a/addon/models/route-cache.js
+++ b/addon/models/route-cache.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+export default Ember.Object.extend({
+  key: '',
+  html: '',
+  expires: ''
+});

--- a/addon/models/route-meta.js
+++ b/addon/models/route-meta.js
@@ -1,0 +1,9 @@
+import Ember from 'ember';
+
+export default Ember.Object.extend({
+  title: null,
+  description: null,
+  keywords: null,
+  shortcut: null,
+  images: null
+});

--- a/addon/models/route-visit.js
+++ b/addon/models/route-visit.js
@@ -1,0 +1,23 @@
+import Ember from 'ember';
+import RouteCache from './route-cache';
+import RouteMeta from './route-meta';
+
+export default Ember.Object.extend({
+  url: null,
+  path: null,
+  name: null,
+  route: null,
+  title: null,
+  params: null,
+
+  meta: null,
+  cache: null,
+
+  init() {
+    this._super();
+    let meta = this.meta || {};
+    let cache = this.cache || {};
+    this.cache = RouteCache.create(cache);
+    this.meta = RouteMeta.create(meta);
+  }
+});

--- a/addon/services/extended-router.js
+++ b/addon/services/extended-router.js
@@ -1,0 +1,110 @@
+import Ember from 'ember';
+
+const {
+  computed,
+  observer,
+  Service,
+  inject
+  } = Ember;
+
+export default Service.extend({
+  history: null
+});
+
+
+/*
+ export default Service.extend({
+ router: computed(function() {
+ return this.container.lookupFactory('router:main');
+ }),
+ service: inject.service('router'),
+ '-service': inject.service('-router'),
+
+ history: null,
+
+ path: null,
+ name: null,
+ route: null,
+ url: null,
+ title: null,
+ meta: {
+ shortcut: null,
+
+ },
+
+ transitionTo: function() {
+ let route = this.get('application');
+ route.transitionTo.apply(route, arguments);
+ },
+ /*
+ url: computed('router.urlHistory.[]', function() {
+ let urls = this.get('router.urlHistory');
+ let last = urls ? urls.objectAt(urls.get('length') - 1) : '';
+ return last ? last.url : '';
+ }).readOnly(),
+
+
+ setTitle: observer('title', function() {
+ window.document.title = this.get('title');
+ })
+
+ });
+
+ var Router = Ember.Router.extend({
+
+ location: config.locationType,
+
+ urlHistory : [],
+
+ /*
+ Provide the ability to retrieve urls from history
+ by adding new urls to urlHistory when the route
+ changes
+
+ updateUrlHistory: observer('_location', 'url', 'location', function() {
+ schedule('afterRender', this, function() {
+ var location = this.get('_location') || this.get('location');
+ var url = location.lastSetURL || this.get('url');
+ this.get('urlHistory').pushObject({ url : url});
+ });
+ })
+
+ });
+
+ /*
+ export default {
+ name: "router",
+ after: "store",
+
+ initialize: function (registry, application) {
+ application.inject('controller:application', 'router', 'router:main');
+ application.inject('service:router-extended', 'router', 'router:main');
+ application.inject('service:router-extended', 'application', 'route:application');
+ }
+
+ };
+
+ export default Route.extend({
+
+ routerExt: inject.service('router-extended'),
+
+ afterModel() {
+ this._super.apply(this, arguments);
+ window.scrollTo(0, 0);
+ this.set('routerExt.currentRoute', this);
+ },
+
+ actions: {
+
+ willTransition() {
+ blurAll();
+ },
+
+ didTransition() {
+ this.set('routerExt.currentRouteName', this.get('routeName'));
+ }
+
+ }
+
+ });
+ */

--- a/app/services/extended-router.js
+++ b/app/services/extended-router.js
@@ -1,0 +1,1 @@
+export { default } from 'smoke-and-mirrors/services/extended-router';

--- a/tests/dummy/app/screens/examples/index/route.js
+++ b/tests/dummy/app/screens/examples/index/route.js
@@ -1,0 +1,3 @@
+import Route from 'smoke-and-mirrors/extensions/route';
+
+export default Route.extend({});

--- a/tests/unit/services/extended-router-test.js
+++ b/tests/unit/services/extended-router-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('service:extended-router', 'Unit | Service | extended router', {
+  // Specify the other units that are required for this test.
+  // needs: ['service:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  var service = this.subject();
+  assert.ok(service);
+});


### PR DESCRIPTION
Ambitious Projects need ambitious routing.  Ember's router has often been "good enough", but doesn't offer many routing features needed for ambitious animations and mobile applications.

This PR introduces several new features, but to use them you will (currently) need to extend your Routes from `smoke-and-mirrors/extensions/route.js`.

Concepts
- `route`: an extended Route object that helps keep track of location and exposes a new hook: `meta(controller, model) {}`.
- `service:extended-router`: similar to the elusive `-router` service, but with the ability to navigate forward and back through your application's route history, trigger a new transition, and to examine the history.
- `route-meta`: stores the meta information for a route returned by the meta hook.
- `route-cache`: stores cached `html` from the route, useful for better animated transitions.
- `route-visit`: stores information about a visit, including url, params, meta, and DOM. This is essentially a history object

