### PR TITLE
First iteration of visualization aid for edge debugging

### DIFF
--- a/addon/components/vertical-collection.js
+++ b/addon/components/vertical-collection.js
@@ -6,7 +6,7 @@ const {
   Component
 } = Ember;
 
-export default Component.extend(OcclusionMixin, {
+var VerticalCollection = Component.extend(OcclusionMixin, {
 
 
   layout: layout,
@@ -61,3 +61,81 @@ export default Component.extend(OcclusionMixin, {
   alwaysUseDefaultHeight: false
 
 });
+
+Ember.runInDebug(() => {
+  const {
+    observer,
+    run
+  } = Ember;
+
+  const appendDivs = () => {
+    const appendDebugDiv = cssClass => {
+      return $(`<div class="${cssClass}"></div>`).appendTo('.zoomed-edge-visualization');
+    };
+
+    $zoomContainer = $('<div class="zoomed-edge-visualization"></div>').appendTo('body');
+    $highlightViewport = appendDebugDiv('highlight-viewport');
+    $highlightVisible = appendDebugDiv('highlight-visible'); 
+    $highlightInvisible = appendDebugDiv('highlight-invisible');
+  };
+
+  const updateEdgeVisuals = (edges, width) => {
+    const updateDebugDiv = ($e, posArgs) => {
+      posArgs.height = (posArgs.bottom - posArgs.top) + 'px';
+      posArgs.top += 'px';
+      posArgs.width = width;
+      $e.css(posArgs);
+    };
+
+    updateDebugDiv($highlightViewport, { top: edges.viewportTop, bottom: edges.viewportBottom });
+    updateDebugDiv($highlightVisible, { top: edges.visibleTop, bottom: edges.visibleBottom });
+    updateDebugDiv($highlightInvisible, { top: edges.invisibleTop, bottom: edges.invisibleBottom });
+  };
+
+  const removeDivs = (edges) => {
+    $zoomContainer.remove();
+
+    $zoomContainer = null;
+    $highlightViewport = null;
+    $highlightVisible = null;
+    $highlightInvisible = null;
+  };
+
+  let $zoomContainer;
+  let $highlightViewport;
+  let $highlightVisible;
+  let $highlightInvisible;
+  let divsAreInDOM = false;
+
+  VerticalCollection.reopen({
+    showEdges: false,
+
+    toggleEdgeVisualization () {
+      this.toggleProperty('showEdges');
+    },
+
+    __edgeVisualizationObserver: observer('showEdges', '_edges', function () {
+      run.scheduleOnce('render', this, '__updateEdgeVisualization');
+    }),
+
+    __updateEdgeVisualization () {
+      if (this.get('showEdges')) {
+        let edges = this.get('_edges');
+        let width = this._$container.width();
+
+        if (divsAreInDOM) {
+          updateEdgeVisuals(edges, width);
+        } else {
+          appendDivs();
+          updateEdgeVisuals(edges, width);
+          divsAreInDOM = true;
+        }
+      } else if (divsAreInDOM) {
+        removeDivs();
+        divsAreInDOM = false;
+      }
+    }
+  });
+});
+
+export default VerticalCollection;

--- a/addon/mixins/occlusion-collection.js
+++ b/addon/mixins/occlusion-collection.js
@@ -15,7 +15,7 @@ const {
   get: get,
   Mixin,
   computed,
-  run,
+  run
   } = Ember;
 
 const actionContextCacheKeys = {
@@ -932,6 +932,4 @@ export default Mixin.create(keyForItem, {
       this.set('didReceiveAttrs', this._didReceiveAttrs);
     }
   }
-
-
 });

--- a/addon/styles/app.css
+++ b/addon/styles/app.css
@@ -44,33 +44,3 @@ vertical-item::after {
   position: relative;
 }
 
-/* these classes are used as a visual aid for debugging edge calculations */
-.zoomed-edge-visualization {
-  zoom: 10%;
-  top: 50%;
-  position: fixed;
-}
-
-.highlight-viewport, .highlight-visible, .highlight-invisible {
-  position: absolute;
-  opacity: 0.6;
-  border-color: black;
-  border-width: 2px;
-  border-style: solid; 
-  pointer-events: none;
-}
-
-.highlight-viewport {
-  background-color: #D4A190;
-  z-index: 100002;
-}
-
-.highlight-visible {
-  background-color: #A1D490;
-  z-index: 100001;
-}
-
-.highlight-invisible {
-  background-color: #90C3D4;
-  z-index: 100000;
-}

--- a/addon/styles/app.css
+++ b/addon/styles/app.css
@@ -43,3 +43,34 @@ vertical-item::after {
   clear: both;
   position: relative;
 }
+
+/* these classes are used as a visual aid for debugging edge calculations */
+.zoomed-edge-visualization {
+  zoom: 10%;
+  top: 50%;
+  position: fixed;
+}
+
+.highlight-viewport, .highlight-visible, .highlight-invisible {
+  position: absolute;
+  opacity: 0.6;
+  border-color: black;
+  border-width: 2px;
+  border-style: solid; 
+  pointer-events: none;
+}
+
+.highlight-viewport {
+  background-color: #D4A190;
+  z-index: 100002;
+}
+
+.highlight-visible {
+  background-color: #A1D490;
+  z-index: 100001;
+}
+
+.highlight-invisible {
+  background-color: #90C3D4;
+  z-index: 100000;
+}

--- a/index.js
+++ b/index.js
@@ -6,6 +6,10 @@ module.exports = {
 
   included : function (app) {
     app.import(app.bowerDirectory + '/animation-frame/AnimationFrame.min.js');
+
+    if (!/production/.test(app.env)) {
+      app.import('./vendor/debug.css');
+    }
   },
 
   isDevelopingAddon: function() {

--- a/vendor/debug.css
+++ b/vendor/debug.css
@@ -1,0 +1,30 @@
+/* these classes are used as a visual aid for debugging edge calculations */
+.zoomed-edge-visualization {
+  zoom: 10%;
+  top: 50%;
+  position: fixed;
+}
+
+.highlight-viewport, .highlight-visible, .highlight-invisible {
+  position: absolute;
+  opacity: 0.6;
+  border-color: black;
+  border-width: 2px;
+  border-style: solid; 
+  pointer-events: none;
+}
+
+.highlight-viewport {
+  background-color: #D4A190;
+  z-index: 100002;
+}
+
+.highlight-visible {
+  background-color: #A1D490;
+  z-index: 100001;
+}
+
+.highlight-invisible {
+  background-color: #90C3D4;
+  z-index: 100000;
+}


### PR DESCRIPTION
This patch adds a simple edge calculation visual debugging aid. It's only included in development builds and can be toggled with the `toggleEdgeVisualization` method.

![edges1](https://cloud.githubusercontent.com/assets/3794475/10708355/d45d4b66-79ca-11e5-9e86-0992aef1d51d.png)
