### PR TITLE
add width, height attribute bindings to async-image

### DIFF
--- a/addon/components/async-image.js
+++ b/addon/components/async-image.js
@@ -15,12 +15,14 @@ export default Component.extend({
   title: null,
   alt: null,
   src: null,
+  width: null,
+  height: null,
 
   // image
   _src: null,
   _image: null,
 
-  attributeBindings: ['_src:src', 'title', 'alt'],
+  attributeBindings: ['_src:src', 'title', 'alt', 'width', 'height'],
   classNames: ['async-image'],
   classNameBindings: ['imgState'],
 


### PR DESCRIPTION
not in this pull request but currently broken: `isFailed` never gets set causing broken images to stay in `isLoading` forever

another thing that's a little annoying is that switching the src causes the image to flash. it would be nice if the old image would stay while the new image is loaded. maybe with a timeout. but i am not sure if this is in the spirit of the new lightwight async-image
