### PR TITLE
Fix style warning

### DIFF
--- a/addon/components/vertical-collection.js
+++ b/addon/components/vertical-collection.js
@@ -45,8 +45,21 @@ const VerticalCollection = Component.extend(OcclusionMixin, {
    * calculations.  This works for height or width changes, it's value is
    * never actually used.
    */
-  containerSize: null
+  containerSize: null,
 
+  _spacerAboveStyle: Ember.computed('__smSpacerAboveHeight', function () {
+    return this._spacerString(this.get('__smSpacerAboveHeight'));
+  }),
+
+  _spacerBelowStyle: Ember.computed('__smSpacerBelowHeight', function () {
+    return this._spacerString(this.get('__smSpacerBelowHeight'));
+  }),
+
+  _spacerString(height) {
+    return new Ember.Handlebars.SafeString(
+      `width: 100%; height: ${height}px;`
+    );
+  }
 });
 
 Ember.runInDebug(() => {

--- a/addon/templates/components/vertical-collection.hbs
+++ b/addon/templates/components/vertical-collection.hbs
@@ -1,7 +1,7 @@
 {{#if __smIsLoadingAbove}}
   {{component loadingAboveComponent}}
 {{/if}}
-<div style="width: 100%; height: {{__smSpacerAboveHeight}}px;"></div>
+<div style={{_spacerAboveStyle}}></div>
 {{#each _content key='@index' as |item index|}}
   {{#vertical-item
     itemTagName=itemTagName
@@ -19,7 +19,7 @@
 {{else}}
   {{yield to="inverse"}}
 {{/each}}
-<div style="width: 100%; height: {{__smSpacerBelowHeight}}px;"></div>
+<div style={{_spacerBelowStyle}}></div>
 {{#if __smIsLoadingBelow}}
   {{component loadingBelowComponent}}
 {{/if}}

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ module.exports = {
   },
 
   isDevelopingAddon: function() {
-    return true;
+    return false;
   }
 
 };


### PR DESCRIPTION
Currently using `vertical-collection` results in the following warning:

```
WARNING: Binding style attributes may introduce cross-site scripting vulnerabilities; please ensure that
values being bound are properly escaped. For more information, including how to disable this warning,
see http://emberjs.com/deprecations/v1.x/#toc_binding-style-attributes.
```

This removes that warning.
