### PR TITLE
Fixing links to runspired blog

### DIFF
--- a/tests/dummy/app/screens/index/template.hbs
+++ b/tests/dummy/app/screens/index/template.hbs
@@ -11,7 +11,7 @@
                   This repo is currently running smoke-and-mirrors {{version}} against Ember {{emberVersion}}
               </li>
             <li class="bg-success">
-                0.4.0 and 0.4.1 were release on Wednesday, October 28. Blog posts coming shortly on <a href="https://blog.runspired.com">Runspired.com</a>.
+                0.4.0 and 0.4.1 were release on Wednesday, October 28. Blog posts coming shortly on <a href="http://blog.runspired.com">Runspired.com</a>.
             </li>
               <li class="bg-warning">
                  Because of the complicated (but ultimately highly successful) nature of the internal scroll
@@ -21,7 +21,7 @@
               </li>
               <li class="bg-info">
                   1.0 is now scheduled for release on Wednesday, November 25th.
-                  A blog post will accompany the release on <a href="https://blog.runspired.com">Runspired.com</a>
+                  A blog post will accompany the release on <a href="http://blog.runspired.com">Runspired.com</a>
               </li>
           </ul>
         </div>


### PR DESCRIPTION
The links to the runspired blog on http://runspired.github.io/smoke-and-mirrors/ are broken.  They point to https, which results in a 403.  This changes them to http, which work fine.

not working with https:
![runspired-403](https://cloud.githubusercontent.com/assets/345985/13300788/97b8c004-daf6-11e5-95af-6f459477e0bb.png)

working with http links:
![runspired-working](https://cloud.githubusercontent.com/assets/345985/13300787/97b87ff4-daf6-11e5-9177-f6d03ed8661e.png)
