### PR TITLE
Add itemClassNames to vertical-collection.

### DIFF
--- a/addon/components/vertical-collection.js
+++ b/addon/components/vertical-collection.js
@@ -45,7 +45,12 @@ const VerticalCollection = Component.extend(OcclusionMixin, {
    * calculations.  This works for height or width changes, it's value is
    * never actually used.
    */
-  containerSize: null
+  containerSize: null,
+
+  /*
+   * Classes to add to the `vertical-item`
+   */
+  itemClassNames: ''
 
 });
 

--- a/addon/templates/components/vertical-collection.hbs
+++ b/addon/templates/components/vertical-collection.hbs
@@ -1,6 +1,7 @@
 {{#each _content key='@index' as |item index|}}
   {{#vertical-item
     itemTagName=itemTagName
+    classNames=itemClassNames
     defaultHeight=defaultHeight
     alwaysUseDefaultHeight=alwaysUseDefaultHeight
     content=item

--- a/tests/integration/components/vertical-collection-test.js
+++ b/tests/integration/components/vertical-collection-test.js
@@ -49,6 +49,28 @@ test('The Collection Renders when content is empty', function(assert) {
   });
 });
 
+test('Adds classes to vertical-items', function(assert) {
+  assert.expect(2);
+
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+  this.set('items', Ember.A([Ember.Object.create({ text: 'b' })]));
+
+  // Template block usage:
+  this.render(hbs`
+  <div style="height: 500px; width: 500px;">
+    {{#vertical-collection content=items itemClassNames='cool classes' as |item|}}
+      {{item.text}}
+    {{/vertical-collection}}
+  </div>
+  `);
+
+  return wait().then(() => {
+    assert.ok(this.$('vertical-item').hasClass('cool'), 'should have cool class');
+    assert.ok(this.$('vertical-item').hasClass('classes'), 'should have classes class');
+  });
+});
+
 /*
 test("The Collection Reveals it's children when `renderAllInitially` is true.", function(assert) {
   assert.expect(1);


### PR DESCRIPTION
This allows for custom classes on `vertical-item`s. @runspired I know you mentioned you were heads down on the next release, so if this gets in the way I can keep the changes in a fork for now.

I also wasn't sure if you would want this to follow similar behavior to `itemTagName`, but figured this would be a good starting point for discussion if so.
