### PR TITLE
Verify presence of objects before calling destroy and forEach

### DIFF
--- a/addon/models/radar.js
+++ b/addon/models/radar.js
@@ -322,17 +322,23 @@ export default class Radar {
   destroy() {
     this._teardownHandlers();
     this._teardownHooks();
-    this.satellites.forEach((satellite) => {
-      satellite.destroy();
-    });
+    if(this.satellites) {
+      this.satellites.forEach((satellite) => {
+        satellite.destroy();
+      });
+    }
     this.satellites = null;
     this.telescope = null;
     this.sky = null;
 
-    this.planet.destroy();
+    if(this.planet) {
+      this.planet.destroy();
+    }
     this.planet = null;
     this.scrollContainer = null;
-    this.skyline.destroy();
+    if(this.skyline) {
+      this.skyline.destroy();
+    }
     this.skyline = null;
   }
 


### PR DESCRIPTION
In our project, we have used `vertical-collection` component to display list of offers. We have used it in the tab-pages, and when we switch between the tabs immediately, it was giving error:

```
TypeError: Cannot read property 'destroy' of null at ListRadar.destroy 
```

at https://github.com/runspired/smoke-and-mirrors/blob/develop/addon/models/radar.js#L332

and 

```
TypeError: Cannot read property 'forEach' of null at ListRadar.destroy 
```

at https://github.com/runspired/smoke-and-mirrors/blob/develop/addon/models/radar.js#L325

Here we have added a simple check to verify the presence of those objects which fixed issue for us.

@runspired can you please verify it and let me know if any details needed.
Thanks :)
