### PR TITLE
fix: lastVisibleChanged action triggers for all visible items

### DIFF
--- a/addon/components/vertical-collection/component.js
+++ b/addon/components/vertical-collection/component.js
@@ -509,10 +509,6 @@ const VerticalCollection = Component.extend({
             index: bottomComponentIndex
           });
         }
-        this.sendActionOnce('lastVisibleChanged', {
-          item: component,
-          index: bottomComponentIndex
-        });
 
         // above the lower reveal boundary (componentTop < edges.visibleBottom)
       } else {
@@ -527,6 +523,11 @@ const VerticalCollection = Component.extend({
 
       bottomComponentIndex++;
     }
+
+    this.sendActionOnce('lastVisibleChanged', {
+      item: childComponents[bottomComponentIndex - 1],
+      index: bottomComponentIndex - 1
+    });
 
     toCull = toCull
       .concat((childComponents.slice(0, topComponentIndex)))

--- a/tests/integration/components/vertical-collection-test.js
+++ b/tests/integration/components/vertical-collection-test.js
@@ -103,6 +103,29 @@ test('Scroll to last item when actual item sizes are significantly larger than d
     });
 });
 
+test('Sends the last visible changed action', function(assert) {
+  const done = assert.async();
+
+  this.set('items', Array(50).fill({ text: 'b' }));
+  this.on('lastVisibleChanged', (item) => {
+    assert.equal(item.index, 30, 'the last visible changed should be item 30');
+    done();
+  });
+
+  this.render(hbs`
+  <div style="height: 200px; width: 100px;" class="scrollable">
+    {{#vertical-collection
+      defaultHeight=10
+      bufferSize=0
+      content=items
+      lastVisibleChanged='lastVisibleChanged' as |item|}}
+      {{item.text}}
+    {{/vertical-collection}}
+  </div>
+  `);
+
+  wait().then(() => this.$('.scrollable').scrollTop(100));
+});
 
 /*
 test("The Collection Reveals it's children when `renderAllInitially` is true.", function(assert) {


### PR DESCRIPTION
Change to only trigger once for the last visible item.

Also adding Ember run to a couple of DOM event handlers and some JSCS fixes for the tests.
