### PR TITLE
fix(scroll-handler): only update scroll handler length when elements array changes

### DIFF
--- a/addon/-private/radar/utils/scroll-handler.js
+++ b/addon/-private/radar/utils/scroll-handler.js
@@ -13,9 +13,9 @@ export class ScrollHandler {
   }
 
   addElementHandler(element, handler) {
-    let index = this.length++;
-
     if (this.elements.indexOf(element) === -1) {
+      let index = this.length++;
+
       if (index === this.maxLength) {
         this.maxLength *= 2;
         this.elements.length = this.maxLength;


### PR DESCRIPTION
I noticed that `vertical-collection` throws an error when you load 2 instances on the same page:

`scroll-handler.js:96 Uncaught TypeError: Cannot read property 'scrollTop' of undefined`

This was because `this.length` didn't match the number of elements in `this.elements` when `addElementHandler` is called twice with the same `element` (The `Container`)
