### PR TITLE
Fix: Decouple resizing from recomputing the container location

### DIFF
--- a/addon/-private/radar/models/geography.js
+++ b/addon/-private/radar/models/geography.js
@@ -8,7 +8,7 @@ export default class Geography {
   }
 
   setState(state) {
-    state = state || this.element.getBoundingClientRect();
+    state = state || this.computeState();
 
     // copying over ensures we preserve shape from outside sources
     // and enables write ops as ClientRect can't be written
@@ -29,6 +29,10 @@ export default class Geography {
       width: this.width,
       height: this.height
     };
+  }
+
+  computeState() {
+    return this.element.getBoundingClientRect();
   }
 
   destroy() {

--- a/addon/-private/radar/models/list-radar.js
+++ b/addon/-private/radar/models/list-radar.js
@@ -23,17 +23,6 @@ export default class ListRadar extends Radar {
     return sat;
   }
 
-  _resize() {
-    for (let i = 0; i < this.length; i++) {
-      let satellite = this.satellites[i];
-      const change = satellite.resize();
-
-      if (change) {
-        ListRadar.adjustSatelliteList(satellite, change);
-      }
-    }
-  }
-
   _adjust(satellite, change) {
     ListRadar.adjustSatelliteList(satellite, change);
   }
@@ -43,5 +32,4 @@ export default class ListRadar extends Radar {
       satellite.shift(change.dY, change.dX);
     }
   }
-
 }

--- a/addon/-private/radar/models/list-satellite.js
+++ b/addon/-private/radar/models/list-satellite.js
@@ -4,8 +4,12 @@ const LIST_SAT_POOL = new FastArray(200, 'ListSatellite Pool');
 
 export default class ListSatellite extends Satellite {
 
-  heightDidChange(dY) {
+  _heightDidChange(dY) {
     this.radar._adjust(this, { dX: 0, dY });
+  }
+
+  heightDidChange(dY) {
+    return this._heightDidChange(dY);
   }
 
   next() {
@@ -33,6 +37,8 @@ export default class ListSatellite extends Satellite {
 
   destroy() {
     this._destroy();
+
+    this.heightDidChange = this._heightDidChange;
 
     LIST_SAT_POOL.push(this);
   }

--- a/addon/-private/radar/models/satellite.js
+++ b/addon/-private/radar/models/satellite.js
@@ -43,31 +43,44 @@ export default class Satellite {
   widthDidChange(/* delta */) {}
 
   recalc() {
-    let cached = this.geography.getState();
-
     this.resize();
+    this.reposition();
+  }
 
-    let dY = this.geography.top - cached.top;
-    let dX = this.geography.left - cached.left;
+  reposition() {
+    const cached = this.geography.getState();
+    const newPosition = this.geography.computeState();
 
-    this.willShift(dY, dX);
-    this.didShift(dY, dX);
+    let dY = newPosition.top - cached.top;
+    let dX = newPosition.left - cached.left;
+
+    this.shift(dY, dX);
   }
 
   resize() {
     const cached = this.geography.getState();
 
-    this.geography.setState();
+    const newState = this.geography.computeState();
 
-    const heightChange = this.geography.height - cached.height;
-    const widthChange = this.geography.width - cached.width;
+    const heightChange = newState.height - cached.height;
+    const widthChange = newState.width - cached.width;
 
     if (heightChange) {
       this.heightDidChange(-1 * heightChange);
     }
+
     if (widthChange) {
       this.widthDidChange(-1 * widthChange);
     }
+
+    this.geography.setState({
+      top: this.geography.top,
+      bottom: this.geography.top + newState.height,
+      left: this.geography.left,
+      right: this.geography.left + newState.width,
+      height: newState.height,
+      width: newState.width,
+    });
 
     return heightChange || widthChange ? { dX: widthChange, dY: heightChange } : undefined;
   }


### PR DESCRIPTION
# What's in this PR?

There was an issue when using inertia scrolling on iOS devices where the [`requestAnimationFrame` callback](https://github.com/runspired/smoke-and-mirrors/blob/a912964e0bf64b40a8d87646deddf798a7d3fd08/addon/-private/radar/utils/scroll-handler.js#L67) would be fired after the [`verticalItem.show()`](https://github.com/runspired/smoke-and-mirrors/blob/51d71e8a893f41fa2769c74aeb588fe970af3e39/addon/components/vertical-collection/component.js#L625). 

This means that [`satellite.resize()`](https://github.com/runspired/smoke-and-mirrors/blob/058a3b4c31806313d20473209fac1b434f4b5712/addon/-private/radar/models/satellite.js#L57) would get triggered causing the radar to shift only that element to a new scroll height. When the `requestAnimationFrame` callback is eventually called, it would shift that element again by `dx` & `dy` resulting in that particular element being shifted twice. 

After some time, you would get into a state where the first "visible" element would be incorrectly computed and you would get something like this:

<img width="415" alt="screen shot 2016-09-19 at 9 49 16 pm" src="https://cloud.githubusercontent.com/assets/779421/18656951/ec1eaa9a-7eb2-11e6-8aee-8f55940766c5.png">
## Decisions Made

I tried fixing this by changing `resize` to only handle resizing the element, any required shifting will be handled by the `radar`.
## 

Note: I also removed the [`ListRadar._resize() override`](https://github.com/runspired/smoke-and-mirrors/compare/develop...GetJobber:bugfix/resize-issues#diff-044c8ae7ce21c6732b6b3e8b501c8691L26) because I _think_ it was redundant, the `list-satellite` implements a [`heightChanged`](https://github.com/runspired/smoke-and-mirrors/blob/058a3b4c31806313d20473209fac1b434f4b5712/addon/-private/radar/models/list-satellite.js#L8) handler that will fire the `adjust` already. I don't think it affects the solution so it may be more appropriate to split it into a different PR.
