### PR TITLE
fix(list-satellite): don't stub methods on destroy

### DIFF
--- a/addon/-private/radar/models/satellite.js
+++ b/addon/-private/radar/models/satellite.js
@@ -100,12 +100,6 @@ export default class Satellite {
     this.geography.destroy();
     this.geography = undefined;
     this.radar = undefined;
-
-    // teardown hooks
-    this.willShift = noop;
-    this.didShift = noop;
-    this.heightDidChange = noop;
-    this.widthDidChange = noop;
   }
 
   static create(options) {


### PR DESCRIPTION
Noticed some unusual behaviour when recreating a VerticalCollection, because we reuse instances of the `ListSatellite` class we can't stub out the `heightDidChange` when it is destroyed

``` js
var foo = ListSatellite.create({ ... });
foo.heightDidChange // "function(dY) { this.radar..."
foo.destroy();

var bar = ListSatellite.create({ ... });
foo.heightDidChange // noop (expect: "function(dY) { this.radar...")
```
