### PR TITLE
Fix: remove dependency on empty object

### DIFF
--- a/addon/-private/ember/empty-object.js
+++ b/addon/-private/ember/empty-object.js
@@ -1,3 +1,20 @@
-import emberRequire from './ext-require';
+// https://github.com/emberjs/ember.js/blob/v2.9.0-beta.2/packages/ember-utils/lib/empty-object.js
 
-export default emberRequire('ember-metal/empty_object');
+// This exists because `Object.create(null)` is absurdly slow compared
+// to `new EmptyObject()`. In either case, you want a null prototype
+// when you're treating the object instances as arbitrary dictionaries
+// and don't want your keys colliding with build-in methods on the
+// default object prototype.
+const proto = Object.create(null, {
+  // without this, we will always still end up with (new
+  // EmptyObject()).constructor === Object
+  constructor: {
+    value: undefined,
+    enumerable: false,
+    writable: true
+  }
+});
+
+function EmptyObject() {}
+EmptyObject.prototype = proto;
+export default EmptyObject;

--- a/addon/-private/ember/ext-require.js
+++ b/addon/-private/ember/ext-require.js
@@ -1,7 +1,0 @@
-import Ember from 'ember';
-
-export default function(moduleName, exportName = 'default') {
-  let module = Ember.__loader.require(moduleName);
-
-  return module[exportName];
-}


### PR DESCRIPTION
Ember 2.9.0-beta.2 moved the EmptyObject class from ember-metal to ember-utils, breaking the require statement. I played around with three ideas:
1. Add an Ember version check in to toggle which module to load (`ember-metal/empty_object` vs `ember-utils/empty-object`). This would be tricky as we would have to not only check for 2.9 but 2.9.0-beta.1 still uses ember-metal; or
2. Use `Object.create(null)` in `addon/-private/cache-list/index.js`, which is the only place EmptyObject is used; or
3. Include a copy of the EmptyObject code

Looking at the use of EmptyObject here it's [inside of a loop](https://github.com/runspired/smoke-and-mirrors/blob/develop/addon/-private/cache-list/index.js#L46) so I'm guessing there is benefit in still using it over `Object.create(null)`. Given how small the code is to create the EmptyObject class it seemed better to include a copy of it then require it from the ember internals.

I am happy to change it to a different solution. Also, I removed `ext-require` as it was only used to require EmptyObject.
