### PR TITLE
fix(debug): prefer the use of ui.write over console.info

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ module.exports = {
     this._setupBabelOptions(app.env);
 
     if (!/production/.test(app.env)) {
-      console.info(
+      this.ui.write(
         chalk.grey("\n===================================================================\n") +
         chalk.cyan("\tSmoke-and-mirrors\n") +
         chalk.grey("\t:: Including CSS for Visual Debugger\n") +


### PR DESCRIPTION
My projects CI server has the `ember test` command output its contents in xml format. This project has a `console.info` statement that gets executed in non-production environments, and this console output gets captured in the stdout redirection we use, thus making the xml file invalid.

Ember CLI has solved this by adding a `--silent` flag to the command line which in turn sets the log level for their UI class. By using `this.ui.write` over `console.info` we can respect the `--silent` flag when it's present:

<details>
<summary>

Before:</summary>



```
[pgrippi ~/Sources/smoke-and-mirrors] [master] ❯ npm-exec ember test --silent

===================================================================
  Smoke-and-mirrors
  :: Including CSS for Visual Debugger
  :: (included in non production builds only)
  :: To use, set {{vertical-collection debug=true}}
===================================================================

ok 1 PhantomJS 2.1 - Integration | Component | occludable area: it renders
...
```

</details>

<details>
<summary>

After:</summary>



```
[pgrippi ~/Sources/smoke-and-mirrors] [master] ❯ npm-exec ember test --silent
ok 1 PhantomJS 2.1 - Integration | Component | occludable area: it renders
...

[pgrippi ~/Sources/smoke-and-mirrors] [master] ❯ npm-exec ember test

===================================================================
    Smoke-and-mirrors
    :: Including CSS for Visual Debugger
    :: (included in non production builds only)
    :: To use, set {{vertical-collection debug=true}}
===================================================================
Built project successfully. Stored in "/Users/petergrippi/Sources/smoke-and-mirrors/tmp/core_object-tests_dist-MD91bBvD.tmp".
ok 1 PhantomJS 2.1 - Integration | Component | occludable area: it renders
...
```

</details>
