### PR TITLE
feat(collection-debugging) adds check for css rules

### DIFF
--- a/addon/components/vertical-collection/component.js
+++ b/addon/components/vertical-collection/component.js
@@ -11,7 +11,10 @@ const {
   K,
   get,
   computed,
-  Component
+  Component,
+  Logger,
+  isBlank,
+  getOwner
 } = Ember;
 
 function valueForIndex(arr, index) {
@@ -593,6 +596,10 @@ const VerticalCollection = Component.extend({
     this._computeEdges();
     this._initializeScrollState();
     this._scheduleUpdate();
+    // Check are we in dev environment
+    if (getOwner(this).resolveRegistration('config:environment').environment === 'development') {
+      this._checkCssRules();
+    }
   },
 
   // –––––––––––––– Setup/Teardown
@@ -870,6 +877,21 @@ const VerticalCollection = Component.extend({
     const newInitialKey = this.keyForItem(newInitialItem, lengthDifference);
 
     return oldInitialKey === newInitialKey;
+  },
+
+  _checkCssRules() {
+    if (this.$().css('display') !== 'block') {
+      Logger.warn('Verical-Collection needs a value of block on display property to function correctly');
+    }
+    if (isBlank(this.$().css('height'))) {
+      Logger.warn('Verical-Collection needs a value on height to function correctly');
+    }
+    if (isBlank(this.$().css('max-height'))) {
+      Logger.warn('Verical-Collection needs a value on max-height to function correctly');
+    }
+    if (this.$().css('position') !== 'relative') {
+      Logger.warn('Vertical-Collection needs a value of relative on position to function correctly');
+    }
   },
 
   didReceiveAttrs() {},


### PR DESCRIPTION
Addresses #59 
Was going to add an intergration test along the lines of 

```
vertical-collection-test.js

test('Test for css rule that may break func', function(assert) {
      this.render(hbs`
         <div id="error-prone-css">
           {{#vertical-collection}}
           {{/vertical-collection}}
         </div>
     `);

      // Assert Logger was called with the help of sinon?
});

dummy app.css

/* Used to test css rules */
#error-prone-css vertical-collection {
  display: flex !important;
  position: absolute !important;
}
```

If it might be helpful? :)
