### PR TITLE
replace `Promise` with `Ember.RSVP.Promise` global in scroll-handler

### DIFF
--- a/addon/-private/radar/utils/scroll-handler.js
+++ b/addon/-private/radar/utils/scroll-handler.js
@@ -1,3 +1,4 @@
+import Ember from 'ember';
 import scheduler from '../../scheduler';
 
 const DEFAULT_ARRAY_SIZE = 10;
@@ -80,7 +81,7 @@ export class ScrollHandler {
         info.left = cachedLeft;
 
         if (topChanged || leftChanged) {
-          Promise.resolve(info)
+          Ember.RSVP.Promise.resolve(info)
             .then((info) => {
               for (let j = 0; j < info.handlers.length; j++) {
                 info.handlers[j].call(null, { top: info.top, left: info.left });


### PR DESCRIPTION
This is to fix a bug I'm presented with where IE11 doesn't have native `Promise` support:

![screen shot 2016-11-28 at 15 17 16](https://cloud.githubusercontent.com/assets/1538479/20672083/4cb86248-b580-11e6-90c5-3c6d57f04833.png)

