### PR TITLE
Vertical Collection when collection starts off screen

### DIFF
--- a/addon/components/vertical-collection/component.js
+++ b/addon/components/vertical-collection/component.js
@@ -539,9 +539,10 @@ const VerticalCollection = Component.extend({
       bottomComponentIndex++;
     }
 
+    const lastVisibleIndex = bottomComponentIndex === 0 ? 0 : bottomComponentIndex - 1;
     this.sendActionOnce('lastVisibleChanged', {
-      item: childComponents[bottomComponentIndex - 1],
-      index: bottomComponentIndex - 1
+      item: childComponents[lastVisibleIndex],
+      index: lastVisibleIndex
     });
 
     toCull = toCull


### PR DESCRIPTION
Closes #150 

This simply creates a floor for the index of the lastVisible Component Index which was causing errors when the vertical collection originates off the screen.