### PR TITLE
fix(component): Update reference to remove deprecated ember-getowner-polyfill

### DIFF
--- a/addon/components/vertical-item/component.js
+++ b/addon/components/vertical-item/component.js
@@ -1,10 +1,10 @@
 import Ember from 'ember';
 import layout from './template';
-import getOwner from 'ember-getowner-polyfill';
 import scheduler from '../../-private/scheduler';
 
 const {
-  Component
+  Component,
+  getOwner
   } = Ember;
 
 /*

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "chalk": "^1.1.3",
     "ember-cli-babel": "^5.1.6",
     "ember-cli-htmlbars": "^1.0.3",
-    "ember-getowner-polyfill": "^1.0.0",
+    "ember-getowner-polyfill": "^1.2.5",
     "perf-primitives": "0.0.4"
   },
   "ember-addon": {


### PR DESCRIPTION
fixes #160 